### PR TITLE
削除機能実装、マイページのビューファイルpost変数表示に変更

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -2,5 +2,10 @@ class PostsController < ApplicationController
 
   def index
   end
-  
+
+  def destroy
+    @post = Post.find(params[:id])
+    @post.destroy
+    redirect_to user_path(current_user.id)
+  end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,2 +1,6 @@
 class UsersController < ApplicationController
+  def show
+    @user = User.find(params[:id])
+    @posts = @user.posts.order("created_at DESC")
+  end
 end

--- a/app/models/m_cate.rb
+++ b/app/models/m_cate.rb
@@ -4,7 +4,7 @@ class M_cate < ActiveHash::Base
     { id: 104, name: 'Java'},{ id: 105, name: 'JavaScript'},
     { id: 201, name: 'Ruby on Rails'},{ id: 202, name: 'BootStrap'},{ id: 203, name: 'Django'},
     { id: 204, name: 'Spring'},
-    { id: 301, name: 'VSコード'},{ id: 302, name: 'Atom'},{ id: 303, name: 'メモ帳'}
+    { id: 301, name: 'VSコード'},{ id: 302, name: 'Atom'},{ id: 303, name: 'メモ帳'},
     { id: 401, name: 'Heroku'},{ id: 402, name: 'AWS'},
     { id: 501, name: 'Git'},
     { id: 601, name: 'MySQL'},

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,6 +1,5 @@
 class Post < ApplicationRecord
   belongs_to :user
-  belongs_to_active_hash :s_cate
   has_many :favorites
   has_many :favorite_users, through: :favorites, source: :user
   

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -27,21 +27,25 @@
   <div class="main">
     <h2><%= current_user.nickname %>さんの投稿一覧</h2>
     <div class="my-index">
-      <div class="my-post-header">
-        <div class="my-post-date"> 投稿日時：2021/09/05 17:20 </div>
-        <div class="my-post-edit"> <a href="#"> 編集 </a></div>
-        <div class="my-post-delete"> <a href="#"> 削除 </a></div>
-      </div>
-      <div class="my-post-body">
-        <div class="my-post-title"> タイトル：<a href="#"> 3回目投稿 </a></div>
-        <div class="my-post-favorite"> ☆300 </div>
-      </div>
-      <div class="my-post-category">
-        <div class="cate-head">  カテゴリー：</div>
-        <div class="my-post-cate">  <a href="#"> テキストエディタ </a></div>
-        <div class="my-post-cate"> <a href="#"> VScode </a></div>
-        <div class="my-post-cate"> <a href="#"> 拡張機能 </a> </div>
-      </div>
+      <% @posts.each do |post| %>
+        <div class="my-post-header">
+          <div class="my-post-date"> 投稿日時：<%= post.created_at %> </div>
+          <% if user_signed_in? && @user.id == current_user.id%>
+            <div class="my-post-edit"> <%= link_to "編集", edit_post_path(post.id) %></div>
+            <div class="my-post-delete"> <%= link_to "削除", post_path(post.id), method: :delete %></div>
+          <% end %>
+        </div>
+        <div class="my-post-body">
+          <div class="my-post-title"> タイトル：<a href="#"> <%= post.title %> </a></div>
+          <div class="my-post-favorite"> ☆<%= post.favorites.count %> </div>
+        </div>
+        <div class="my-post-category">
+          <div class="cate-head">  カテゴリー：</div>
+          <div class="my-post-cate">  <a href="#"> <%= post.l_cate.name %> </a></div>
+          <div class="my-post-cate"> <a href="#"> <%= post.m_cate.name %> </a></div>
+          <div class="my-post-cate"> <a href="#"> <%= post.s_cate.name %> </a> </div>
+        </div>
+      <% end %>
     </div>
     <div class="my-index">
       <div class="my-post-header">


### PR DESCRIPTION
# What
- 削除機能(posts#destroy)記述
- マイページ（users#show）に@user,@posts変数の定義
- マイページのビューファイルのpost一覧表示をpost変数表示に変更
- マイページのビューファイルの編集・削除リンク変更
- postモデルファイル「belongs_to_active_hash :s_cate」の記述を削除
- m_cateアクティブモデル内「{ id: 301, name: 'VSコード'},{ id: 302, name: 'Atom'},{ id: 303, name: 'メモ帳'}」の文末に「,」を追記

# Why
- 投稿記事に対しての削除機能実装のため
- マイページビューファイル投稿一覧を変数化するため
- 前回マージ時のエラー対策の微修正