### PR TITLE
Posts#index,posts#select category index,users#show周辺機能の実装

### DIFF
--- a/app/assets/stylesheets/posts/index.css
+++ b/app/assets/stylesheets/posts/index.css
@@ -9,16 +9,16 @@
   height: 100%;
   display: flex;
   justify-content: center;
-}
-.post, .post-pick {
-  background-color: white;
-  height: 100vh;
-  margin-top: 30px;
-}
-.post {
-  width: 40%;
+  padding: 15px;
 }
 .post-pick {
   margin-left: 20px;
   width: 30%;
+  height: 100vh;
+  background-color: rgb(252, 233, 198);
+  border-radius: 10px;
+  padding: 10px;
+  margin-top: 15px;
+  margin-left: 10px;
+  margin-right: 10px;
 }

--- a/app/assets/stylesheets/posts/index.css
+++ b/app/assets/stylesheets/posts/index.css
@@ -1,3 +1,9 @@
+.message{
+  padding: 20px 0 5px 100px;
+  font-size: 25px;
+  background-color: #f6f6f4;
+  
+}
 .posts-index {
   background-color: #f6f6f4;
   height: 100%;

--- a/app/assets/stylesheets/shared/header.css
+++ b/app/assets/stylesheets/shared/header.css
@@ -25,20 +25,12 @@
   padding: 5px 10px;
 }
 .category_list{
-  display: flex;
+  display: none;
   position: absolute;
   height: 340px;
   width: 540px;
 }
-.now-selected-parent{
-  background-color: rgb(223, 219, 219);
-  padding: 5px 10px;
-}
-.now-selected-child{
-  background-color: rgb(223, 219, 219);
-  padding: 5px 10px;
-}
-.now-selected-grand-child{
+.now-selected-parent,.now-selected-child,.now-selected-grand-child{
   background-color: rgb(223, 219, 219);
   padding: 5px 10px;
 }
@@ -50,39 +42,21 @@
   padding: 5px 10px;
 }
 .header-bottom-right-content ul{
+  padding: 0;
+  margin: 0;
   list-style: none;
   width: 180px;
 }
 .header-bottom-right-content li{
   padding: 5px 10px;
 }
-.parents_list{
+.parents_list, .children_list, .grand_children_list{
   display: none;
   width: 180px;
   height: 340px;
   background-color: snow;
 }
-.children_list{
-  display: none;
-  width: 180px;
-  height: 340px;
-  background-color: snow;
-}
-.grand_children_list{
-  display: none;
-  width: 180px;
-  height: 340px;
-  background-color: snow;
-}
-.parent_category{
-  text-decoration: none;
-  color: black;
-}
-.child_category{
-  text-decoration: none;
-  color: black;
-}
-.grand_child_category{
+.parent_category,.child_category,.grand_child_category{
   text-decoration: none;
   color: black;
 }

--- a/app/assets/stylesheets/shared/registration.css
+++ b/app/assets/stylesheets/shared/registration.css
@@ -8,11 +8,15 @@
 }
 .shader-registration-left h1{
   font-size: 30px;
+  font-weight: normal;
   margin-bottom: 10px;
 }
 .shader-registration-left ul{
+  padding: 0;
+  margin: 0;
   padding-left: 10px;
   font-size: 15px;
+  list-style: none;
 }
 .shader-registration {
   margin-right: 30px;

--- a/app/assets/stylesheets/users/users_show.scss
+++ b/app/assets/stylesheets/users/users_show.scss
@@ -12,7 +12,7 @@
   font-weight: 200;
 }
 
-.main h2{
+.main h2,.post-pick h2{
   margin-bottom: 10px;
   letter-spacing: 3px;
   font-size: 20px;
@@ -56,7 +56,7 @@
 .my-cate{
   padding: 5px 10px;
   font-size: 11px;
-  background-color: rgb(190, 187, 187);
+  background-color: #f6f6f4;
   margin-top: 10px;
   text-align: center;
 }
@@ -79,7 +79,8 @@
 }
 
 .main{
-  width: 70%;
+  width: 60%;
+  height: 100vh;
   background-color: rgb(252, 233, 198);
   border-radius: 10px;
   padding: 10px;
@@ -131,12 +132,12 @@
 .my-post-cate{
   padding: 5px 10px;
   font-size: 11px;
-  background-color: rgb(190, 187, 187);
+  background-color: #f6f6f4;
   margin-right: 5px;
   text-align: center;
 }
 
-.my-post-cate a{
+a{
   text-decoration: none;
   color: black;
 }

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -68,8 +68,9 @@ class PostsController < ApplicationController
       if post_array.present?
         post_array.each do |post|
           if post.present?
-          else
             @posts.push(post)
+          else
+            
           end
         end
       end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -3,6 +3,7 @@ class PostsController < ApplicationController
 
   def index
     @posts = Post.all.order("created_at DESC")
+    @user = User.find(current_user.id)
   end
 
   def new
@@ -55,6 +56,7 @@ class PostsController < ApplicationController
       find_post(category)
       @message = "『 #{@category.parent.name} 』 > 『 #{@category.name} 』の検索結果"
     end
+    @user = User.find(current_user.id)
     render :index
   end
 

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,9 +1,8 @@
 class PostsController < ApplicationController
-  before_action :set_category_list, only: [:index]
+  before_action :set_category_list, only: [:index, :new, :select_category_index]
 
   def index
     @posts = Post.all.order("created_at DESC")
-    
   end
 
   def new
@@ -41,31 +40,22 @@ class PostsController < ApplicationController
   end
   
   def select_category_index
-    # カテゴリ名を取得するために@categoryにレコードをとってくる
     @category = Category.find_by(id: params[:id])
-
-    # 親カテゴリーを選択していた場合の処理
     if @category.ancestry == nil
-      # Categoryモデル内の親カテゴリーに紐づく孫カテゴリーのidを取得
       category = Category.find_by(id: params[:id]).indirect_ids
-      # 孫カテゴリーに該当するpostsテーブルのレコードを入れるようの配列を用意
       @posts = []
-      # find_itemメソッドで処理
       find_post(category)
-
-    # 孫カテゴリーを選択していた場合の処理
+      @message = "『 #{@category.name} 』の検索結果"
     elsif @category.ancestry.include?("/")
-      # Categoryモデル内の親カテゴリーに紐づく孫カテゴリーのidを取得
       @posts = Post.where(category_id: params[:id])
-
-    # 子カテゴリーを選択していた場合の処理
+      @message = "『 #{@category.parent.parent.name} 』 > 『 #{@category.parent.name} 』 > 『 #{@category.name} 』の検索結果"
     else
       category = Category.find_by(id: params[:id]).child_ids
-      # 孫カテゴリーに該当するitemsテーブルのレコードを入れるようの配列を用意
       @posts = []
-      # find_itemメソッドで処理
       find_post(category)
+      @message = "『 #{@category.parent.name} 』 > 『 #{@category.name} 』の検索結果"
     end
+    render :index
   end
 
   private

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,4 +1,5 @@
 class UsersController < ApplicationController
+  before_action :set_category_list, only: :show
   def show
     @user = User.find(params[:id])
     @posts = @user.posts.order("created_at DESC")

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -4,12 +4,12 @@
 // that code so it'll be compiled.
 
 import Rails from "@rails/ujs"
-import Turbolinks from "turbolinks"
+// import Turbolinks from "turbolinks"
 import * as ActiveStorage from "@rails/activestorage"
 import "channels"
 
 Rails.start()
-Turbolinks.start()
+// Turbolinks.start()
 ActiveStorage.start()
 
 require("jquery")

--- a/app/javascript/search.js
+++ b/app/javascript/search.js
@@ -12,10 +12,12 @@ $(function() {
 
   $(".cate-title").on("mouseenter", function() {
     $(this).attr({"style": "color: blue;"});
+    $(".category_list").attr({"style": "display:flex;"});
     $(".parents_list").attr({"style": "display:block;"});
   });
   $(".category_list").on("mouseleave", function() {
     $(".now-selected-parent").removeClass("now-selected-parent")
+    $(".category_list").attr({"style": "display:none;"});
     $(".cate-title").attr({"style": "color: black;"});
     $(".parents_list").attr({"style": "display:none;"});
     $(".children_list").attr({"style": "display:none;"});

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -2,6 +2,9 @@
 <% unless  user_signed_in? %>
   <%= render "shared/registrations" %>
 <% end %>
+<div class="message">
+  <%= @message %>
+</div>
 <div class="posts-index">
   <div class="post">
     <p>ユーザーネーム 2021年09月10日</p>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -6,21 +6,12 @@
   <%= @message %>
 </div>
 <div class="posts-index">
-  <div class="post">
-    <p>ユーザーネーム 2021年09月10日</p>
-    <p>タイトル              お気に入り(btn)</p>
-    <p>Ruby,Ruby on Rails,</p>
-
-    <p>ユーザーネーム 2021年09月10日</p>
-    <p>タイトル              お気に入り(btn)</p>
-    <p>Ruby,Ruby on Rails,</p>
-
-    <p>ユーザーネーム 2021年09月10日</p>
-    <p>タイトル              お気に入り(btn)</p>
-    <p>Ruby,Ruby on Rails,</p>
+  <div class="main">
+    <h2>投稿一覧</h2>
+    <%= render partial: "shared/post_index", locals: { posts: @posts } %>
   </div>
   <div class="post-pick">
-    <p>最もお気に入りされている記事</p>
+    <h2>最もお気に入りされている記事</h2>
     <p>記事名（タイトル）お気に入りされている数</p>
   </div>
 </div>

--- a/app/views/posts/select_category_index.html.erb
+++ b/app/views/posts/select_category_index.html.erb
@@ -1,7 +1,0 @@
-<div>test</div>
-<div>test</div>
-<div>test</div>
-<div>test</div>
-<div>test</div>
-<%= @category.name%>の検索結果
-<%= link_to "トップページ",root_path %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,6 +1,6 @@
 <div class="shared-header">
   <div class="header-left-content">
-    <p>EN2(logo)</p>
+    <%= link_to "EN2(logo)", root_path %>
   </div>
   <div class="header-right-content">
     <%= button_to "投稿", {controller: 'posts', action: 'new'}, {method: :get, class: 'new-btn'} %>

--- a/app/views/shared/_post_index.html.erb
+++ b/app/views/shared/_post_index.html.erb
@@ -1,0 +1,25 @@
+<% if posts.present? %>
+  <% posts.each do |post| %>
+    <div class="my-index">
+      <div class="my-post-header">
+        <div class="my-post-date"> 投稿日時　<%= post.created_at.strftime("%Y/%m/%d %H:%M") %> </div>
+        <% if user_signed_in? && @user.id == current_user.id%>
+          <div class="my-post-edit"> <%= link_to "編集", edit_post_path(post.id) %></div>
+          <div class="my-post-delete"> <%= link_to "削除", post_path(post.id), method: :delete %></div>
+        <% end %>
+      </div>
+      <div class="my-post-body">
+        <div class="my-post-title"> タイトル： <%= link_to "#{post.title}", post_path(post.id), method: :get %> </div>
+        <%# <div class="my-post-favorite"> ☆<%= post.favorites.count </div> %>
+      </div>
+      <div class="my-post-category">
+        <div class="cate-head">  カテゴリー：</div>
+        <%= link_to "#{post.category.parent.parent.name}",select_category_index_post_path(post.category.parent.parent.id), class: "my-post-cate" %>
+        <%= link_to "#{post.category.parent.name}",select_category_index_post_path(post.category.parent.id), class: "my-post-cate" %>
+        <%= link_to "#{post.category.name}",select_category_index_post_path(post.category.id), class: "my-post-cate" %>
+      </div>
+    </div>
+  <% end %>
+<% else %>
+  <p>現在、投稿されている記事はありません。</p>
+<% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -26,8 +26,8 @@
   </div>
   <div class="main">
     <h2><%= current_user.nickname %>さんの投稿一覧</h2>
-    <div class="my-index">
-      <% @posts.each do |post| %>
+    <% @posts.each do |post| %>
+      <div class="my-index">
         <div class="my-post-header">
           <div class="my-post-date"> 投稿日時：<%= post.created_at %> </div>
           <% if user_signed_in? && @user.id == current_user.id%>
@@ -37,16 +37,16 @@
         </div>
         <div class="my-post-body">
           <div class="my-post-title"> タイトル：<a href="#"> <%= post.title %> </a></div>
-          <div class="my-post-favorite"> ☆<%= post.favorites.count %> </div>
+          <%# <div class="my-post-favorite"> ☆<%= post.favorites.count </div> %>
         </div>
         <div class="my-post-category">
           <div class="cate-head">  カテゴリー：</div>
-          <div class="my-post-cate">  <a href="#"> <%= post.l_cate.name %> </a></div>
-          <div class="my-post-cate"> <a href="#"> <%= post.m_cate.name %> </a></div>
-          <div class="my-post-cate"> <a href="#"> <%= post.s_cate.name %> </a> </div>
+          <%= link_to "#{post.category.parent.parent.name}",select_category_index_post_path(post.category.parent.parent.id), class: "my-post-cate" %>
+          <%= link_to "#{post.category.parent.name}",select_category_index_post_path(post.category.parent.id), class: "my-post-cate" %>
+          <%= link_to "#{post.category.name}",select_category_index_post_path(post.category.id), class: "my-post-cate" %>
         </div>
-      <% end %>
-    </div>
+      </div>
+    <% end %>
     <div class="my-index">
       <div class="my-post-header">
         <div class="my-post-date"> 投稿日時：2021/09/04 19:20 </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -26,60 +26,6 @@
   </div>
   <div class="main">
     <h2><%= current_user.nickname %>さんの投稿一覧</h2>
-    <% @posts.each do |post| %>
-      <div class="my-index">
-        <div class="my-post-header">
-          <div class="my-post-date"> 投稿日時：<%= post.created_at %> </div>
-          <% if user_signed_in? && @user.id == current_user.id%>
-            <div class="my-post-edit"> <%= link_to "編集", edit_post_path(post.id) %></div>
-            <div class="my-post-delete"> <%= link_to "削除", post_path(post.id), method: :delete %></div>
-          <% end %>
-        </div>
-        <div class="my-post-body">
-          <div class="my-post-title"> タイトル：<a href="#"> <%= post.title %> </a></div>
-          <%# <div class="my-post-favorite"> ☆<%= post.favorites.count </div> %>
-        </div>
-        <div class="my-post-category">
-          <div class="cate-head">  カテゴリー：</div>
-          <%= link_to "#{post.category.parent.parent.name}",select_category_index_post_path(post.category.parent.parent.id), class: "my-post-cate" %>
-          <%= link_to "#{post.category.parent.name}",select_category_index_post_path(post.category.parent.id), class: "my-post-cate" %>
-          <%= link_to "#{post.category.name}",select_category_index_post_path(post.category.id), class: "my-post-cate" %>
-        </div>
-      </div>
-    <% end %>
-    <div class="my-index">
-      <div class="my-post-header">
-        <div class="my-post-date"> 投稿日時：2021/09/04 19:20 </div>
-        <div class="my-post-edit"> <a href="#"> 編集 </a></div>
-        <div class="my-post-delete"> <a href="#"> 削除 </a></div>
-      </div>
-      <div class="my-post-body">
-        <div class="my-post-title"> タイトル：<a href="#"> 2回目投稿 </a></div>
-        <div class="my-post-favorite"> ☆1000 </div>
-      </div>
-      <div class="my-post-category">
-        <div class="cate-head">  カテゴリー：</div>
-        <div class="my-post-cate">  <a href="#"> フレームワーク </a></div>
-        <div class="my-post-cate"> <a href="#"> ruby on rails </a></div>
-        <div class="my-post-cate"> <a href="#"> MVC </a> </div>
-      </div>
-    </div>
-    <div class="my-index">
-      <div class="my-post-header">
-        <div class="my-post-date"> 投稿日時：2021/09/04 18:50</div>
-        <div class="my-post-edit"> <a href="#"> 編集 </a></div>
-        <div class="my-post-delete"> <a href="#"> 削除 </a></div>
-      </div>
-      <div class="my-post-body">
-        <div class="my-post-title"> タイトル：<a href="#"> 初投稿 </a></div>
-        <div class="my-post-favorite"> ☆533 </div>
-      </div>
-      <div class="my-post-category">
-        <div class="cate-head">  カテゴリー：</div>
-        <div class="my-post-cate">  <a href="#"> 言語 </a></div>
-        <div class="my-post-cate"> <a href="#"> ruby </a></div>
-        <div class="my-post-cate"> <a href="#"> 環境構築 </a> </div>
-      </div>
-    </div>
+    <%= render partial: "shared/post_index", locals: { posts: @posts } %>
   </div>
 </div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -34,5 +34,6 @@ module Myapp
 
     # Don't generate system test files.
     config.generators.system_tests = nil
+    config.time_zone = 'Tokyo'
   end
 end


### PR DESCRIPTION
# What
- posts#select category indexのビューファイルの削除
- posts#select category indexアクション後posts#indexへrenderするように記述変更＋message変数の設定
- users#showビューファイルのpost一覧表示のカテゴリー検索リンクを設定
- 投稿一覧共通部分テンプレートによりコードをまとめた
- 投稿日時を日本時間（年/月/日　時:分）表示になるように修正
- その他ビューの微修正
- find_postメソッド内のposts.pushの記述位置の変更
- リセットCSS対策

# Why
- アプリの統一感を出すため
- 多重コードの修正
- posts#select category index実行時に孫要素のカテゴリーにしか検索が反応しなかったため