### PR TITLE
お気に入り投稿一覧

### DIFF
--- a/app/assets/stylesheets/users/users_show.scss
+++ b/app/assets/stylesheets/users/users_show.scss
@@ -52,17 +52,15 @@
   color: black;
 }
 
-.my-cate{
+
+.favorite-user{
   padding: 5px 10px;
-  font-size: 11px;
+  font-size: 20px;
   background-color: #f6f6f4;
   margin-top: 10px;
-  text-align: center;
-}
-
-.my-cate a{
-  text-decoration: none;
-  color: black;
+  margin-left: 15%;
+  width: 70%;
+  display: block;
 }
 
 .user-name{
@@ -139,4 +137,17 @@
 a{
   text-decoration: none;
   color: black;
+}
+
+.my-post-bottom{
+  display: flex;
+}
+
+.my-post-favorite{
+  display: flex;
+}
+.post-favorite-icon{
+  height: 18px;
+  width: 18px;
+  margin: 0 5px 3px 5px;
 }

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -63,15 +63,15 @@ class PostsController < ApplicationController
       category = Category.find_by(id: params[:id]).indirect_ids
       @posts = []
       find_post(category)
-      @message = "『 #{@category.name} 』の検索結果"
+      @message = "『 #{@category.name} 』の検索結果 : #{@posts.length}件"
     elsif @category.ancestry.include?("/")
       @posts = Post.where(category_id: params[:id])
-      @message = "『 #{@category.root.name} 』 > 『 #{@category.parent.name} 』 > 『 #{@category.name} 』の検索結果"
+      @message = "『 #{@category.root.name} 』 > 『 #{@category.parent.name} 』 > 『 #{@category.name} 』の検索結果 : #{@posts.length}件"
     else
       category = Category.find_by(id: params[:id]).child_ids
       @posts = []
       find_post(category)
-      @message = "『 #{@category.root.name} 』 > 『 #{@category.name} 』の検索結果"
+      @message = "『 #{@category.root.name} 』 > 『 #{@category.name} 』の検索結果 : #{@posts.length}件"
     end
     @posts = sort_post(@posts)
     @posts = Kaminari.paginate_array(@posts).page(params[:page])
@@ -81,8 +81,8 @@ class PostsController < ApplicationController
   def keyword_search
     @posts = Post.search_keyword(params[:keyword])
     @posts = sort_post(@posts)
+    @message = "『 #{params[:keyword]} 』の検索結果 : #{@posts.length}件"
     @posts = Kaminari.paginate_array(@posts).page(params[:page])
-    @message = "『 #{params[:keyword]} 』の検索結果"
     render :index
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,8 +1,25 @@
 class UsersController < ApplicationController
-  before_action :authenticate_user!, only: :show
-  before_action :set_category_list, only: :show
+  before_action :authenticate_user!, only: [:show, :favorite_posts_show]
+  before_action :set_category_list, only: [:show, :favorite_posts_show]
+  before_action :set_users_content, only: [:show, :favorite_posts_show]
   def show
-    @user = User.find(params[:id])
     @posts = @user.posts.order("created_at DESC").page(params[:page]).per(10)
+    @message = "#{@user.nickname}さんの投稿一覧"
+  end
+
+  def favorite_posts_show
+    @posts = @user.favorite_words.order("created_at DESC").page(params[:page]).per(10)
+    @message = "お気に入り投稿一覧"
+    render :show
+  end
+
+  private
+  def set_users_content
+    @user = User.find(params[:id])
+    @favorite_posts = @user.favorite_words.order("created_at DESC").limit(5)
+    @favorite_users = []
+    @favorite_posts.each do |favo_post|
+      @favorite_users.push(favo_post.user)
+    end
   end
 end

--- a/app/views/shared/_post_index.html.erb
+++ b/app/views/shared/_post_index.html.erb
@@ -12,11 +12,30 @@
         <div class="my-post-title"> タイトル： <%= link_to "#{post.title}", post_path(post.id), method: :get %> </div>
         <%# <div class="my-post-favorite"> ☆<%= post.favorites.count </div> %>
       </div>
-      <div class="my-post-category">
-        <div class="cate-head">  カテゴリー：</div>
-        <%= link_to "#{post.category.parent.parent.name}",select_category_index_post_path(post.category.parent.parent.id), class: "my-post-cate" %>
-        <%= link_to "#{post.category.parent.name}",select_category_index_post_path(post.category.parent.id), class: "my-post-cate" %>
-        <%= link_to "#{post.category.name}",select_category_index_post_path(post.category.id), class: "my-post-cate" %>
+      <div class="my-post-bottom">
+        <div class="my-post-category">
+          <div class="cate-head">  カテゴリー：</div>
+          <%= link_to "#{post.category.parent.parent.name}",select_category_index_post_path(post.category.parent.parent.id), class: "my-post-cate" %>
+          <%= link_to "#{post.category.parent.name}",select_category_index_post_path(post.category.parent.id), class: "my-post-cate" %>
+          <%= link_to "#{post.category.name}",select_category_index_post_path(post.category.id), class: "my-post-cate" %>
+        </div>
+        <div class="my-post-favorite">
+          <% if current_user.already_liked?(post) %>
+            <%= button_to post_favorite_path(post), method: :delete, class:"icon-btn" do  %>
+              <%= image_tag 'favorite-true.png', class:"post-favorite-icon" %>
+            <% end %>
+            <div class="post-favorite-count">
+              <p><%= post.favorites.count %></p>
+            </div>
+          <% else %>
+            <%= button_to post_favorites_path(post), class:"icon-btn" do %>
+              <%= image_tag 'favorite.png', class:"post-favorite-icon" %>
+            <% end %>
+            <div class="post-favorite-count">
+              <%= post.favorites.count %>
+            </div>
+          <% end %>
+        </div>
       </div>
     </div>
   <% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -4,28 +4,25 @@
   <div class="side-bar">
     <div class="my-profile">
       <div class="user-name">
-        <h1> <%= current_user.nickname %> </h1>
+        <h1> <%= @user.nickname %> </h1>
       </div>
       <h2>Links</h2>
       <div class="my-links">
-        <div class="my-link"><a href="#">投稿</a></div>
-        <div class="my-link"><a href="#">お気に入り</a></div>
+        <%= link_to "my投稿",user_path(@user.id), class: "my-link" %>
+        <%= link_to "お気に入り",favorite_posts_show_user_path(@user.id), class: "my-link" %>
       </div>
     </div>
     <div class="cate-search">
-      <h2>カテゴリー検索</h2>
+      <h2>お気に入りユーザ</h2>
       <div class="my-cates">
-        <div class="my-cate"><a href="#">pyton</a></div>
-        <div class="my-cate"><a href="#">ruby</a></div>
-        <div class="my-cate"><a href="#">HTML・CSS</a></div>
-        <div class="my-cate"><a href="#">ruby on rails</a></div>
-        <div class="my-cate"><a href="#">javaScript</a></div>
-        <div class="my-cate"><a href="#">jquery</a></div>
+        <% @favorite_users.each do |favorite_user| %>
+          <%= link_to "#{favorite_user.nickname}",user_path(favorite_user.id), class: "favorite-user" %>
+        <% end %>
       </div>
     </div>
   </div>
   <div class="main">
-    <h2><%= current_user.nickname %>さんの投稿一覧</h2>
+    <h2><%= @message %></h2>
     <%= render partial: "shared/post_index", locals: { posts: @posts } %>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,11 @@ Rails.application.routes.draw do
   devise_for :users
   root to:'posts#index'
 
-  resources :users, only: :show
+  resources :users, only: :show do
+    member do
+      get 'favorite_posts_show'
+    end
+  end
   resources :posts do
     resources :favorites, only: [:create, :destroy]
     member do


### PR DESCRIPTION
# What
- 検索時ヒット件数表示
- users#showのカテゴリー検索欄をお気に入りユーザ表示欄に変更
- users#favorite_posts_show（お気に入り投稿一覧）のルーティング・アクション・ビューの追加
- 投稿一覧にお気に入り件数表示

# Why
- 検索したときに何件ヒットしたのかをユーザがすぐにわかるようにするため
- マイページでお気に入りした投稿記事を見直すことができるようにするため
- 投稿一覧で表示されている記事に何件お気に入り登録されているか（人気か）がわかるようにするため