### PR TITLE
トップページ新規ユーザ登録機能

### DIFF
--- a/app/assets/stylesheets/shared/registration.css
+++ b/app/assets/stylesheets/shared/registration.css
@@ -23,6 +23,23 @@
   padding: 0 50px 20px 0;
 }
 .shader-registration-right{
-  padding: 120px 80px 0 0;
-  font-size: 30px;
+  font-size: 15px;
+}
+
+.top-new-registration{
+  display: flex;
+}
+
+.registration-form{
+  margin-right: 10px;
+  padding: 10px;
+}
+
+.registration-actions{
+  margin-right: 120px;
+  margin-top: 180px;
+}
+
+.registration-btn{
+  padding: 5px 10px;
 }

--- a/app/assets/stylesheets/shared/registration.css
+++ b/app/assets/stylesheets/shared/registration.css
@@ -35,9 +35,13 @@
   padding: 10px;
 }
 
+.registration-field-label{
+  margin-top: 7px;
+}
+
 .registration-actions{
   margin-right: 120px;
-  margin-top: 180px;
+  margin-top: 207px;
 }
 
 .registration-btn{

--- a/app/assets/stylesheets/users/users_show.scss
+++ b/app/assets/stylesheets/users/users_show.scss
@@ -16,7 +16,8 @@
   letter-spacing: 3px;
   font-size: 20px;
   font-weight: 200;
-  border-bottom: 3px solid orange;
+  padding-top: 30px;
+  padding-left: 10px;
 }
 
 .side-bar h2{
@@ -77,13 +78,24 @@
 
 .main{
   width: 60%;
-  height: 1120px;
+  height: 1150px;
   background-color: rgb(252, 233, 198);
   border-radius: 10px;
-  padding: 20px;
+  padding: 0 20px;
   margin-top: 15px;
   margin-left: 10px;
   margin-right: 10px;
+}
+
+.main-header{
+  display: flex;
+  justify-content: space-between;
+  border-bottom: 3px solid orange;
+}
+
+.page-content{
+  margin: 0 33% 10px 0;
+  height: 30px;
 }
 
 .my-index{

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -7,7 +7,6 @@ class PostsController < ApplicationController
   before_action :move_to_index, only: [:edit, :update, :destory]
 
   def index
-    @user = User.new
     @posts = Post.all.order("created_at DESC").includes(:user).page(params[:page]).per(10)
   end
 
@@ -91,6 +90,8 @@ class PostsController < ApplicationController
   def set_user
     if user_signed_in?
       @user = User.find(current_user.id)
+    else
+      @user = User.new
     end
   end
 

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -7,6 +7,7 @@ class PostsController < ApplicationController
   before_action :move_to_index, only: [:edit, :update, :destory]
 
   def index
+    @user = User.new
     @posts = Post.all.order("created_at DESC").includes(:user).page(params[:page]).per(10)
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,6 +2,7 @@ class UsersController < ApplicationController
   before_action :authenticate_user!, only: [:show, :favorite_posts_show]
   before_action :set_category_list, only: [:show, :favorite_posts_show]
   before_action :set_users_content, only: [:show, :favorite_posts_show]
+  
   def show
     @posts = @user.posts.order("created_at DESC").page(params[:page]).per(10)
     @message = "#{@user.nickname}さんの投稿一覧"
@@ -21,5 +22,9 @@ class UsersController < ApplicationController
     @favorite_posts.each do |favo_post|
       @favorite_users.push(favo_post.user)
     end
+  end
+
+  def user_params
+    params.require(:user).permit(:nickname, :email, :password, :password_confirmation)
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,7 +2,7 @@ class UsersController < ApplicationController
   before_action :authenticate_user!, only: [:show, :favorite_posts_show]
   before_action :set_category_list, only: [:show, :favorite_posts_show]
   before_action :set_users_content, only: [:show, :favorite_posts_show]
-  
+
   def show
     @posts = @user.posts.order("created_at DESC").page(params[:page]).per(10)
     @message = "#{@user.nickname}さんの投稿一覧"
@@ -22,6 +22,7 @@ class UsersController < ApplicationController
     @favorite_posts.each do |favo_post|
       @favorite_users.push(favo_post.user)
     end
+    @favorite_users = @favorite_users.uniq
   end
 
   def user_params

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -20,7 +20,9 @@ class UsersController < ApplicationController
     @favorite_posts = @user.favorite_words.order("created_at DESC").limit(5)
     @favorite_users = []
     @favorite_posts.each do |favo_post|
-      @favorite_users.push(favo_post.user)
+      if favo_post.user.id != @user.id
+        @favorite_users.push(favo_post.user)
+      end
     end
     @favorite_users = @favorite_users.uniq
   end

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -7,7 +7,12 @@
 </div>
 <div class="posts-index">
   <div class="main">
-    <h2>投稿一覧</h2>
+    <div class="main-header">
+      <h2>投稿一覧</h2>
+      <div class="page-content">
+        <%= paginate @posts %> 
+      </div>
+    </div>
     <%= render partial: "shared/post_index", locals: { posts: @posts } %>
   </div>
   <div class="post-pick">

--- a/app/views/shared/_post_index.html.erb
+++ b/app/views/shared/_post_index.html.erb
@@ -10,7 +10,6 @@
       </div>
       <div class="my-post-body">
         <div class="my-post-title"> タイトル： <%= link_to "#{post.title}", post_path(post.id), method: :get %> </div>
-        <%# <div class="my-post-favorite"> ☆<%= post.favorites.count </div> %>
       </div>
       <div class="my-post-bottom">
         <div class="my-post-category">

--- a/app/views/shared/_post_index.html.erb
+++ b/app/views/shared/_post_index.html.erb
@@ -20,17 +20,25 @@
           <%= link_to "#{post.category.name}",select_category_index_post_path(post.category.id), class: "my-post-cate" %>
         </div>
         <div class="my-post-favorite">
-          <% if current_user.already_liked?(post) %>
-            <%= button_to post_favorite_path(post), method: :delete, class:"icon-btn" do  %>
-              <%= image_tag 'favorite-true.png', class:"post-favorite-icon" %>
+          <% if user_signed_in? %>
+            <% if current_user.already_liked?(post) %>
+              <% favorite = Favorite.find_by(post_id: post.id, user_id: current_user.id) %>
+              <%= button_to post_favorite_path(post,favorite), method: :delete, class:"icon-btn" do  %>
+                <%= image_tag 'favorite-true.png', class:"post-favorite-icon" %>
+              <% end %>
+              <div class="post-favorite-count">
+                <p><%= post.favorites.count %></p>
+              </div>
+            <% else %>
+              <%= button_to post_favorites_path(post), class:"icon-btn" do %>
+                <%= image_tag 'favorite.png', class:"post-favorite-icon" %>
+              <% end %>
+              <div class="post-favorite-count">
+                <%= post.favorites.count %>
+              </div>
             <% end %>
-            <div class="post-favorite-count">
-              <p><%= post.favorites.count %></p>
-            </div>
           <% else %>
-            <%= button_to post_favorites_path(post), class:"icon-btn" do %>
-              <%= image_tag 'favorite.png', class:"post-favorite-icon" %>
-            <% end %>
+            <%= image_tag 'favorite.png', class:"post-favorite-icon" %>
             <div class="post-favorite-count">
               <%= post.favorites.count %>
             </div>

--- a/app/views/shared/_registrations.html.erb
+++ b/app/views/shared/_registrations.html.erb
@@ -13,7 +13,7 @@
     <%= form_with model: @user, url: user_registration_path, class: 'top-new-registration', local: true do |f| %>
       <div class="registration-form">
         <div class="field">
-          <div class='field-label'>
+          <div class='registration-field-label'>
             <%= f.label :nickname, 'ニックネーム' %><br />
           </div>
           <div class='field-input'>
@@ -22,7 +22,7 @@
         </div>
 
         <div class="field">
-          <div class='field-label'>
+          <div class='registration-field-label'>
             <%= f.label :email, 'メールアドレス' %><br />
           </div>
           <div class='field-input'>
@@ -31,7 +31,7 @@
         </div>
 
         <div class="field">
-          <div class='field-label'>
+          <div class='registration-field-label'>
             <%= f.label :password, 'パスワード' %>
             <i>(英数字混合6文字以上)</i><br />
           </div>
@@ -41,7 +41,7 @@
         </div>
 
         <div class="field">
-          <div class='field-label'>
+          <div class='registration-field-label'>
             <%= f.label :password_confirmation, '確認用パスワード' %><br />
           </div>
           <div class='field-input'>

--- a/app/views/shared/_registrations.html.erb
+++ b/app/views/shared/_registrations.html.erb
@@ -10,6 +10,48 @@
     <P>さあ、会員登録して記事を投稿してみましょう！</p>
   </div>
   <div class="shader-registration-right">
-    <%= link_to '⇨  新規会員登録ページへGO！！', new_user_registration_path %>
+    <%= form_with model: @user, url: user_registration_path, class: 'top-new-registration', local: true do |f| %>
+      <div class="registration-form">
+        <div class="field">
+          <div class='field-label'>
+            <%= f.label :nickname, 'ニックネーム' %><br />
+          </div>
+          <div class='field-input'>
+            <%= f.text_field :nickname, autofocus: true, autocomplete: "nickname" %>
+          </div>
+        </div>
+
+        <div class="field">
+          <div class='field-label'>
+            <%= f.label :email, 'メールアドレス' %><br />
+          </div>
+          <div class='field-input'>
+            <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+          </div>
+        </div>
+
+        <div class="field">
+          <div class='field-label'>
+            <%= f.label :password, 'パスワード' %>
+            <i>(英数字混合6文字以上)</i><br />
+          </div>
+          <div class='field-input'>
+            <%= f.password_field :password, autocomplete: "new-password" %>
+          </div>
+        </div>
+
+        <div class="field">
+          <div class='field-label'>
+            <%= f.label :password_confirmation, '確認用パスワード' %><br />
+          </div>
+          <div class='field-input'>
+            <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
+          </div>
+        </div>
+      </div>
+      <div class="registration-actions">
+        <%= f.submit "EN2を始める", class:'registration-btn' %>
+      </div>
+    <% end %>
   </div>
 </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -15,8 +15,12 @@
     <div class="cate-search">
       <h2>お気に入りユーザ</h2>
       <div class="my-cates">
-        <% @favorite_users.each do |favorite_user| %>
-          <%= link_to "#{favorite_user.nickname}",user_path(favorite_user.id), class: "favorite-user" %>
+        <% if @favorite_users.present?%>
+          <% @favorite_users.each do |favorite_user| %>
+            <%= link_to "#{favorite_user.nickname}",user_path(favorite_user.id), class: "favorite-user" %>
+          <% end %>
+        <% else %>
+          お気に入りユーザはいません
         <% end %>
       </div>
     </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -22,7 +22,12 @@
     </div>
   </div>
   <div class="main">
-    <h2><%= @message %></h2>
+    <div class="main-header">
+      <h2><%= @message %></h2>
+      <div class="page-content">
+        <%= paginate @posts %> 
+      </div>
+    </div>
     <%= render partial: "shared/post_index", locals: { posts: @posts } %>
   </div>
 </div>


### PR DESCRIPTION
# What
- トップページに新規ユーザ登録フォームを追加
- トップページお気に入り関連エラー修正
- マイページお気に入りユーザの重複ユーザ表示対策
- ページネーションを一覧の上にも表示＆ビュー修正
- マイページのお気に入りユーザに自分のユーザ名も表示される不具合修正

# Why
- 新規ユーザ登録ページへ遷移しなくてもトップページから登録可能にするため
- postsテーブル内でfavorite定義していなかったためビューで定義してエラーを解消
- マイページのお気に入りユーザが重複したまま表示されてしまうことに対しての対策